### PR TITLE
Fix metadata retrieval under OTP 0.19.x and later.

### DIFF
--- a/src/main/java/com/mecatran/otp/gwt/client/proxies/otp/OtpPlannerProxy.java
+++ b/src/main/java/com/mecatran/otp/gwt/client/proxies/otp/OtpPlannerProxy.java
@@ -374,7 +374,7 @@ public class OtpPlannerProxy implements TransitPlannerProxy {
 	}
 
 	private String buildConfUrl() {
-		return baseUrl + "/routers/" + routerId + "/metadata";
+		return baseUrl + "/routers/" + routerId;
 	}
 
 	private String buildGetUrl(PlanRequestBean planRequest) {


### PR DESCRIPTION
GWT interface doesn't work anymore under OTP 0.19.x. This commit fixes it by correcting metadata URL retrieval.
